### PR TITLE
Catnip behaviors

### DIFF
--- a/Assets/Scenes/LivingRoom.unity
+++ b/Assets/Scenes/LivingRoom.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44503856, g: 0.49462986, b: 0.5737339, a: 1}
+  m_IndirectSpecularColor: {r: 0.44503903, g: 0.49463093, b: 0.573735, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -8780,8 +8780,44 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: e820444f97b3e4e4393a44e1ae502ef2, type: 2}
+    - target: {fileID: 2300000, guid: 9a9b786c8f8ef604bb4f0d82b70a7e26, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9a9b786c8f8ef604bb4f0d82b70a7e26, type: 3}
+--- !u!1 &798265108 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 100000, guid: 9a9b786c8f8ef604bb4f0d82b70a7e26,
+    type: 3}
+  m_PrefabInstance: {fileID: 798265107}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &798265109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 798265108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b53b27f8fbe627479813acfdc9e5398, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &798265110
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 798265108}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 4300000, guid: 9a9b786c8f8ef604bb4f0d82b70a7e26, type: 3}
 --- !u!1 &798731838
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/BehaviorTreeNodes.cs
+++ b/Assets/Scripts/BehaviorTreeNodes.cs
@@ -38,6 +38,42 @@ public class CustomCheckNode : PrimitiveNode
 	}
 }
 
+public class CheckTimerNode : PrimitiveNode
+{
+	public delegate void TimesUpFunction();
+	TimesUpFunction endTimerFunction;
+	
+	bool firstIteration;
+	float startTime;
+	float timerDuration;
+	
+	public CheckTimerNode (Context _context, float _duration, TimesUpFunction _function) : base (_context)
+	{
+		firstIteration = true;
+		timerDuration = _duration;
+		endTimerFunction = _function;
+	}
+	
+	public override NodeStatus run (float _time)
+	{	
+		// If node is being run for the first time, start the timer
+		if (firstIteration)
+		{
+			firstIteration = false;
+			startTime = _time;
+		}
+		
+		if (_time >= startTime + timerDuration)
+		{
+			endTimerFunction();
+			
+			return NodeStatus.Failure;
+		}
+		
+		return NodeStatus.Success;
+	}
+}
+
 
 // Decorators
 public class LoopNode : Node

--- a/Assets/Scripts/Cat.cs
+++ b/Assets/Scripts/Cat.cs
@@ -33,6 +33,9 @@ public class Cat : BaseCat
 	double drag_start_time;
 	public float time_of_last_user_interaction {get; private set;}
 	
+	// Can the cat currently use catnip? (if it is currently on catnip, using more will not do anything in order to prevent catnip buffs from stacking)
+	public bool on_catnip {get; private set;}
+	
 	// UI Buttons
 	private Button hand_button, brush_button, food_button, laser_button, litter_button;
 	public SelectedTool selected_tool {get; private set;}
@@ -64,6 +67,8 @@ public class Cat : BaseCat
 		laserPointerScript = laserPointer.GetComponent<LaserPointer>();
 		// Deactivate laser pointer game object to turn it off
 		laserPointer.SetActive(false);
+		// Cat is not on catnip
+		on_catnip = false;
 		
 		// Get Buttons
 		hand_button = GameObject.Find("hand_button").GetComponent<Button>();
@@ -173,7 +178,7 @@ public class Cat : BaseCat
 		// Update UI
 		stats.UpdateUI();
 
-		// Run behavior tree
+		// Run behavior tree. If a tree is "paused", it will not run.
 		autonomousCatBehaviorTree.run(Time.time);
 		userInteractionBehaviorTree.run(Time.time);
 		
@@ -276,6 +281,42 @@ public class Cat : BaseCat
 
 
  	}
+	
+	public IEnumerator useCatnip()
+    {
+        // Before Wait period:
+		Debug.Log("Using Catnip...");
+		activity.current = CatActivityEnum.OnCatnip;
+		on_catnip = true;
+		// Apply stat buffs
+		personality.fun_buff.Value *= CatPersonality.CATNIP_FUN_BUFF;
+		personality.fun_debuff.Value = CatPersonality.CATNIP_FUN_DEBUFF;
+		personality.energy_debuff.Value *= CatPersonality.CATNIP_ENERGY_DEBUFF;
+		
+		
+        yield return new WaitForSeconds(CatnipScript.CATNIP_TIME_DURATION);
+        
+
+		// After Wait period:
+		Debug.Log("Catnip effects have worn off.");
+		activity.current = CatActivityEnum.Idle;
+		on_catnip = false;
+		// Remove stat buffs
+		personality.fun_buff.Value /= CatPersonality.CATNIP_FUN_BUFF;
+		personality.fun_debuff.Value += CatPersonality.DEFAULT_BUFF_VALUE;
+		personality.energy_debuff.Value /= CatPersonality.CATNIP_ENERGY_DEBUFF;
+		
+    }
+	
+	public void resetActivity()
+	{
+		activity.current = CatActivityEnum.Idle;
+	}
+	
+	public CatActivityEnum getCurrentActivity()
+	{
+		return activity.current;
+	}
 
  	// Pause one behavior tree and activate the other
 	public void turnOnAutonomousCatBehavior()

--- a/Assets/Scripts/Cat.cs
+++ b/Assets/Scripts/Cat.cs
@@ -292,6 +292,7 @@ public class Cat : BaseCat
 		personality.fun_buff.Value *= CatPersonality.CATNIP_FUN_BUFF;
 		personality.fun_debuff.Value = CatPersonality.CATNIP_FUN_DEBUFF;
 		personality.energy_debuff.Value *= CatPersonality.CATNIP_ENERGY_DEBUFF;
+		agent.speed *= CatPersonality.CATNIP_SPEED_BOOST;
 		
 		
         yield return new WaitForSeconds(CatnipScript.CATNIP_TIME_DURATION);
@@ -305,6 +306,7 @@ public class Cat : BaseCat
 		personality.fun_buff.Value /= CatPersonality.CATNIP_FUN_BUFF;
 		personality.fun_debuff.Value += CatPersonality.DEFAULT_BUFF_VALUE;
 		personality.energy_debuff.Value /= CatPersonality.CATNIP_ENERGY_DEBUFF;
+		agent.speed /= CatPersonality.CATNIP_SPEED_BOOST;
 		
     }
 	

--- a/Assets/Scripts/CatPersonality.cs
+++ b/Assets/Scripts/CatPersonality.cs
@@ -150,6 +150,7 @@ public class CatPersonality
 	public const float CATNIP_FUN_BUFF = 1.5F; // Multiply this to fun_buff when cat is on catnip
 	public const float CATNIP_FUN_DEBUFF = 0F; // Set fun_debuff to this value when cat is on catnip
 	public const float CATNIP_ENERGY_DEBUFF = 0.5F; // Multiply this to energy_buff when cat is on catnip
+	public const float CATNIP_SPEED_BOOST = 3F;
 	
 	public Buff energy_buff;
 	public Buff energy_debuff;

--- a/Assets/Scripts/CatPersonality.cs
+++ b/Assets/Scripts/CatPersonality.cs
@@ -1,6 +1,56 @@
 using UnityEngine;
 using UnityEngine.UI;
 
+
+// Container class for stat buffs.
+public class Buff
+{
+	/* Stat Buffs */
+	/* 		"Buffs" affect the rate at which stats increase. 
+			A buff value of 0 means the stat does not increase.
+			A buff value of 1 means the stat increases normally.
+			A buff value of < 1 means the stat increases slower than normal.
+			A buff value of > 1 means that the stat increases faster than normal.
+			
+			"Debuffs" affect the rate at which stats decrease.
+			A debuff value of 0 means the stat does not decrease.
+			A debuff value of 1 means the stat decreases normally.
+			A debuff value of < 1 means the stat decreases slower than normal.
+			A debuff value of > 1 means the stat decreases faster than normal.
+	*/
+	
+	private float _value;
+	public float Value
+	{
+		get {return _value;} 
+		set 
+		{
+			if (value < 0)
+			{
+				_value = 0;
+			}
+			else
+			{
+				_value = value;
+			}
+		}
+	}
+	
+	public Buff ( float _buff_value = CatPersonality.DEFAULT_BUFF_VALUE)
+	{
+		if (_buff_value < 0)
+		{
+			_value = CatPersonality.DEFAULT_BUFF_VALUE;
+		}
+		else 
+		{
+			_value = _buff_value;
+		}
+		
+	}
+	
+}
+
 public class CatPersonality
 {
 	public CatPersonality(float hungriness, float tierdness, float playfullness, float cleanlieness, float sociability, float sleep_threshold = 0.2F, float hunger_threshold = 0.25F, float bladder_threshold = 0.2F)
@@ -23,23 +73,6 @@ public class CatPersonality
 			GameObject.Find("sociability_slider").GetComponent<Slider>().value = (int) 100 * this.sociability;
 			return;
 		}
-
-		// Debug Values
-		/*
-		this.bond_increase_per_second = CalculateMultipier(0.01F, 0.02F, this.sociability);
-		this.bond_increase_when_being_pet_per_second = CalculateMultipier(0.01F, 0.02F, this.sociability);
-		this.bond_increase_per_happieness_per_second = CalculateMultipier(0.01F, 0.02F, this.sociability);
-		this.fullness_decrease_per_second = CalculateMultipier(0.1F, 0.11F, this.hungriness);
-		this.fullness_increase_when_eating_per_second = CalculateMultipier(0.05F, 0.1F, this.hungriness, true);
-		this.energy_decrease_per_second = CalculateMultipier(0.01F, 0.02F, this.tierdness);
-		this.energy_increase_when_sleeping_per_second = CalculateMultipier(0.1F, 0.2F, this.tierdness, true);
-		this.fun_decrease_per_second = CalculateMultipier(0.01F, 0.02F, this.playfullness);
-		this.fun_increase_when_following_laser_per_second = CalculateMultipier(0.05F, 0.1F, this.playfullness);
-		this.fun_increase_when_playing_with_yarn_per_second = CalculateMultipier(0.05F, 0.1F, this.playfullness);
-		this.fun_increase_when_on_catnip_per_second = CalculateMultipier(0.05F, 0.1F, this.playfullness);
-		this.hygiene_decrease_per_second = CalculateMultipier(0.01F, 0.02F, this.cleanlieness);
-		this.hygiene_increase_when_being_brushed_per_second = CalculateMultipier(0.1F, 0.2F, this.cleanlieness);
-		*/
 		
 		this.bond_increase_per_second = CalculateMultipier(0.01F, 0.02F, this.sociability);
 		this.bond_increase_when_being_pet_per_second = CalculateMultipier(0.01F, 0.02F, this.sociability);
@@ -56,6 +89,19 @@ public class CatPersonality
 		this.hygiene_increase_when_being_brushed_per_second = CalculateMultipier(0.1F, 0.2F, this.cleanlieness);
 		this.bladder_decrease_per_second = CalculateMultipier(0.01F, 0.02F, Random.Range(MIN, MAX));
 		this.bladder_increase_when_using_litter_box_per_second = CalculateMultipier(0.1F, 0.2F, Random.Range(MIN, MAX));
+		
+		this.energy_buff = new Buff();
+		this.energy_debuff = new Buff();
+		this.fullness_buff = new Buff();
+		this.fullness_debuff = new Buff();
+		this.fun_buff = new Buff();
+		this.fun_debuff = new Buff();
+		this.hygiene_buff = new Buff();
+		this.hygiene_debuff = new Buff();
+		this.bladder_buff = new Buff();
+		this.bladder_debuff = new Buff();
+		this.bond_buff = new Buff();
+		this.bond_debuff = new Buff();
 	}
 
 	// Generates and returns a random cat personality
@@ -67,6 +113,7 @@ public class CatPersonality
 	// Maximum value a personality trait can have
 	public const float MAX = 1.0F;
 	public const float MIN = 0.0F;
+	
 
 	/** Traits:
           the numbers that define a unique personality **/
@@ -99,6 +146,24 @@ public class CatPersonality
 	private float bladder_decrease_per_second;
 	private float bladder_increase_when_using_litter_box_per_second;
 	
+	public const float DEFAULT_BUFF_VALUE = 1F; // Default multiplier value is normally set to 1, but this can be increased for debugging purposes to make stats increase/decrease faster
+	public const float CATNIP_FUN_BUFF = 1.5F; // Multiply this to fun_buff when cat is on catnip
+	public const float CATNIP_FUN_DEBUFF = 0F; // Set fun_debuff to this value when cat is on catnip
+	public const float CATNIP_ENERGY_DEBUFF = 0.5F; // Multiply this to energy_buff when cat is on catnip
+	
+	public Buff energy_buff;
+	public Buff energy_debuff;
+	public Buff fullness_buff;
+	public Buff fullness_debuff;
+	public Buff fun_buff;
+	public Buff fun_debuff;
+	public Buff hygiene_buff;
+	public Buff hygiene_debuff;
+	public Buff bladder_buff;
+	public Buff bladder_debuff;
+	public Buff bond_buff;
+	public Buff bond_debuff;
+	
 	// Threshold values
 	public float sleep_threshold {get; private set;}		// Cat falls asleep when energy reaches this level
 	public float hunger_threshold {get; private set;}		// Cat tries to eat when fullness reaches this level
@@ -122,89 +187,105 @@ public class CatPersonality
 	public void UpdateStats(ref CatStats stats, CatActivity activity, float dt)
 	{
 		// Update bond
-		stats.Bond += dt * bond_increase_per_second;
+		stats.Bond += dt * bond_increase_per_second * bond_buff.Value;
 		// TODO: lower bond if cat is extreamly unhappy?
-		stats.Bond += dt * bond_increase_per_happieness_per_second;
+		stats.Bond += dt * bond_increase_per_happieness_per_second * bond_buff.Value;
 
 		if (CatActivityEnum.BeingPet == activity.current)
 		{
-			stats.Bond += dt * bond_increase_when_being_pet_per_second;
+			stats.Bond += dt * bond_increase_when_being_pet_per_second * bond_buff.Value;
 		}
 
 		// Update fullness
 		if (CatActivityEnum.Eating == activity.current) 
 		{
-			stats.Fullness += dt * fullness_increase_when_eating_per_second;
+			stats.Fullness += dt * fullness_increase_when_eating_per_second * fullness_buff.Value;
 		} 
 		else 
 		{
-			stats.Fullness -= dt * fullness_decrease_per_second;
+			stats.Fullness -= dt * fullness_decrease_per_second * fullness_debuff.Value;
 		}
 
 		// Update energy
 		if (CatActivityEnum.Sleeping == activity.current) 
 		{
-			stats.Energy += dt * energy_increase_when_sleeping_per_second;
+			stats.Energy += dt * energy_increase_when_sleeping_per_second * energy_buff.Value;
 		} 
 		else 
 		{
-			stats.Energy -= dt * energy_decrease_per_second;
+			stats.Energy -= dt * energy_decrease_per_second * energy_debuff.Value;
 		}
 
 		// Update fun
 		if (CatActivityEnum.PlayingWithYarn == activity.current) 
 		{
-			stats.Fun += dt * fun_increase_when_playing_with_yarn_per_second;
+			stats.Fun += dt * fun_increase_when_playing_with_yarn_per_second * fun_buff.Value;
 		} 
 		else if (CatActivityEnum.FollowingLaser == activity.current) 
 		{
-			stats.Fun += dt * fun_increase_when_following_laser_per_second;
+			stats.Fun += dt * fun_increase_when_following_laser_per_second * fun_buff.Value;
 		} 
 		else if (CatActivityEnum.OnCatnip == activity.current) 
 		{
-			stats.Fun += dt * fun_increase_when_on_catnip_per_second;
+			stats.Fun += dt * fun_increase_when_on_catnip_per_second * fun_buff.Value;
 		} 
 		else 
-{
-			stats.Fun -= dt * fun_decrease_per_second;
+		{
+			stats.Fun -= dt * fun_decrease_per_second * fun_debuff.Value;
 		}
 
 		// Update hygiene
 		if (CatActivityEnum.BeingBrushed == activity.current) 
 		{
-			stats.Hygiene += dt * hygiene_increase_when_being_brushed_per_second;
+			stats.Hygiene += dt * hygiene_increase_when_being_brushed_per_second * hygiene_buff.Value;
 		} 
 		else 
 		{
 			// If cat is using the litterbox, its hygiene stat decays twice as fast
 			if (CatActivityEnum.UsingLitterbox == activity.current)
 			{
-				stats.Hygiene -= dt * 2 * hygiene_decrease_per_second;
+				stats.Hygiene -= dt * 2 * hygiene_decrease_per_second * hygiene_debuff.Value;
 			}
 			else
 			{
-				stats.Hygiene -= dt * hygiene_decrease_per_second;
+				stats.Hygiene -= dt * hygiene_decrease_per_second * hygiene_debuff.Value;
 			}
 		}
 		
 		// Update bladder
 		if (CatActivityEnum.UsingLitterbox == activity.current) 
 		{
-			stats.Bladder += dt * bladder_increase_when_using_litter_box_per_second;
+			stats.Bladder += dt * bladder_increase_when_using_litter_box_per_second * bladder_buff.Value;
 		}
 		else
 		{	// If cat is eating, its bladder stat decays twice as fast
 			if (CatActivityEnum.Eating == activity.current)
 			{
-				stats.Bladder -= dt * 2 * bladder_decrease_per_second;
+				stats.Bladder -= dt * 2 * bladder_decrease_per_second * bladder_debuff.Value;
 			}
 			else 
 			{
-				stats.Bladder -= dt * bladder_decrease_per_second;
+				stats.Bladder -= dt * bladder_decrease_per_second * bladder_debuff.Value;
 			}
 		}
 	}
 	
+	// Resets all stat buffs / debuffs to default value
+	public void resetStatBuffs()
+	{
+		this.energy_buff.Value = DEFAULT_BUFF_VALUE;
+		this.energy_debuff.Value = DEFAULT_BUFF_VALUE;
+		this.fullness_buff.Value = DEFAULT_BUFF_VALUE;
+		this.fullness_debuff.Value = DEFAULT_BUFF_VALUE;
+		this.fun_buff.Value = DEFAULT_BUFF_VALUE;
+		this.fun_debuff.Value = DEFAULT_BUFF_VALUE;
+		this.hygiene_buff.Value = DEFAULT_BUFF_VALUE;
+		this.hygiene_debuff.Value = DEFAULT_BUFF_VALUE;
+		this.bladder_buff.Value = DEFAULT_BUFF_VALUE;
+		this.bladder_debuff.Value = DEFAULT_BUFF_VALUE;
+		this.bond_buff.Value = DEFAULT_BUFF_VALUE;
+		this.bond_debuff.Value = DEFAULT_BUFF_VALUE;
+	}
 	
 	public void Save()
 	{

--- a/Assets/Scripts/CatnipScript.cs
+++ b/Assets/Scripts/CatnipScript.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CatnipScript : MonoBehaviour
+{
+	Cat catScript; // Reference to cat class attached to Cat gameobject
+	public const float CATNIP_TIME_DURATION = 60F; // How long catnip effects will last, in seconds.
+	
+    // Start is called before the first frame update
+    void Start()
+    {
+        catScript = GameObject.Find("Cat").GetComponent<Cat>();
+    }
+	
+	void OnMouseDown()
+	{
+		Debug.Log("Clicked on catnip.");
+		
+		// If not currently on catnip, use catnip
+		if (!catScript.on_catnip)
+		{
+			StartCoroutine(catScript.useCatnip());
+		}
+	}
+	
+}

--- a/Assets/Scripts/CatnipScript.cs.meta
+++ b/Assets/Scripts/CatnipScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b53b27f8fbe627479813acfdc9e5398
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Clicking on the catnip will make the cat be "on catnip". Added stat buff / debuff functionality. Catnip gives the following stat buffs / debuffs:

- Fun stat increases x1.5 faster
- Fun stat will not decrease
- Energy stat decreases x0.5 slower
- Cat speed is x3
- Lasts 60 seconds

I also took steps to ensure that catnip cannot be used again on the same cat while it is already in effect (which would result in the stat buffs / debuffs stacking every time the user clicks the catnip object)